### PR TITLE
Set vexctl generate output as action output

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,11 +21,16 @@ inputs:
   file:
     description: 'Path to the file where the OpenVEX document will be written'
     required: false
+outputs:
+  openvex:
+    description: "Generated OpenVEX document"
+    value: ${{ steps.generate.outputs.openvex }}
 runs:
   using: "composite"
   steps:
     - uses: openvex/setup-vexctl@e85ca48f3c8a376289f6476129d59cda82147e71 # v0.1.1
     - shell: bash
+      id: generate
       run: |
         #!/bin/bash
 
@@ -37,4 +42,6 @@ runs:
           alias log_error="echo \"ERROR:\""
         fi
 
-        vexctl generate "${{ inputs.product }}" --file="${{ inputs.file }}" --templates="${{ inputs.templates-dir }}"
+        echo "openvex<<GITHUB_OUTPUT_EOF" >> $GITHUB_OUTPUT
+        vexctl generate "${{ inputs.product }}" --file="${{ inputs.file }}" --templates="${{ inputs.templates-dir }}"  | tee -a $GITHUB_OUTPUT
+        echo "GITHUB_OUTPUT_EOF" >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,7 @@ inputs:
   file:
     description: 'Path to the file where the OpenVEX document will be written'
     required: false
+    default: '/dev/stdout'
 outputs:
   openvex:
     description: "Generated OpenVEX document"


### PR DESCRIPTION
Example [usage](https://github.com/intel/dffml/blob/bde69fbf8d39bce4ce91070068f13caf3e3eb067/.github/workflows/testing.yml#L14-L151):

```yaml
    - uses: openvex/generate-vex@159b7ee4845fb48f1991395ce8501d6263407360
      name: Run vexctl
      id: vexctl
      with:
        product: pkg:github/${{ github.repository }}@${{ github.sha }}
    - name: Submit OpenVEX to SCITT
      id: scitt-submit-openvex
      uses: scitt-community/scitt-api-emulator@f1f5c16630a28511e970b6903fbc4c0db6c07654
      with:
        issuer: did:web:raw.githubusercontent.com:intel:dffml:public-keys:authorized_keys
        subject: pkg:github/${{ github.repository }}@${{ github.sha }}
        payload: ${{ steps.vexctl.outputs.openvex }}
        private-key-pem: private-key.pem
        scitt-url: https://scitt.unstable.chadig.com
```